### PR TITLE
Windows fix

### DIFF
--- a/manifests/windows_command.pp
+++ b/manifests/windows_command.pp
@@ -17,6 +17,8 @@ define runyer::windows_command (
 
     file { "C:/ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/${action_name}.ddl":
       ensure  => $ensure,
+      owner   => Administrator,
+      group   => Administrators,
       mode    => '0644',
       content => $ddl_file,
       notify  => Service['pe-mcollective'],
@@ -24,6 +26,8 @@ define runyer::windows_command (
 
     file { "C:/ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective/agent/${action_name}.rb":
       ensure  => $ensure,
+      owner   => Administrator,
+      group   => Administrators,
       mode    => '0644',
       content => $rb_file,
       notify  => Service['pe-mcollective'],


### PR DESCRIPTION
Updated logic in windows_command.pp to check if the node is the master node. Current iterations rely on a custom fact, which is not available on all systems, thus causing this to fail on windows nodes.
